### PR TITLE
Add proper static linking support

### DIFF
--- a/lief-sys/CMakeLists.txt
+++ b/lief-sys/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 
 include(ExternalProject)
 
-project(LIEF_SYS LANGUAGES CXX)
+project(lief-sys LANGUAGES CXX)
 
 set(LIEF_PREFIX       "${CMAKE_CURRENT_BINARY_DIR}/LIEF")
 set(LIEF_INSTALL_DIR  "${LIEF_PREFIX}")
@@ -11,8 +11,11 @@ set(LIEF_INCLUDE_DIRS "${LIEF_PREFIX}/include")
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(LIB_LIEF
-        "${LIEF_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}LIEF${CMAKE_STATIC_LIBRARY_SUFFIX}")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib")
+
+set(LIB_LIEF "${LIEF_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}LIEF${CMAKE_STATIC_LIBRARY_SUFFIX}")
 
 set(LIEF_GIT_URL "https://github.com/lief-project/LIEF.git")
 
@@ -61,19 +64,19 @@ ExternalProject_Add(LIEF
         UPDATE_COMMAND   ""
         )
 
-add_library(LIEF_SYS src/liblief.cpp)
+add_library(lief-sys src/liblief.cpp)
 
 if(MSVC)
-    target_compile_options(LIEF_SYS PUBLIC /FIiso646.h)
+    target_compile_options(lief-sys PUBLIC /FIiso646.h)
     if(${CMAKE_BUILD_TYPE} MATCHES "Release")
-        set_property(TARGET LIEF_SYS PROPERTY MSVC_RUNTIME_LIBRARY "/MT")
+        set_property(TARGET lief-sys PROPERTY MSVC_RUNTIME_LIBRARY "/MT")
     else()
-        set_property(TARGET LIEF_SYS PROPERTY MSVC_RUNTIME_LIBRARY "/MTd")
+        set_property(TARGET lief-sys PROPERTY MSVC_RUNTIME_LIBRARY "/MTd")
     endif()
 endif()
 
-target_include_directories(LIEF_SYS PUBLIC ${LIEF_INCLUDE_DIRS})
+target_include_directories(lief-sys PUBLIC ${LIEF_INCLUDE_DIRS})
 
-target_link_libraries(LIEF_SYS PUBLIC ${LIB_LIEF})
+target_link_libraries(lief-sys PUBLIC ${LIB_LIEF})
 
-add_dependencies(LIEF_SYS LIEF)
+add_dependencies(lief-sys LIEF)

--- a/lief-sys/CMakeLists.txt
+++ b/lief-sys/CMakeLists.txt
@@ -71,10 +71,8 @@ if(MSVC)
     endif()
 endif()
 
-
 target_include_directories(LIEF_SYS PUBLIC ${LIEF_INCLUDE_DIRS})
 
 target_link_libraries(LIEF_SYS PUBLIC ${LIB_LIEF})
 
 add_dependencies(LIEF_SYS LIEF)
-

--- a/lief-sys/CMakeLists.txt
+++ b/lief-sys/CMakeLists.txt
@@ -20,26 +20,27 @@ set(LIEF_VERSION 0.11.0)
 
 set(LIEF_CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-        -DLIEF_PE=on
-        -DLIEF_LOGGING=on
-        -DLIEF_ELF=on
-        -DLIEF_MACHO=off
-        -DLIEF_PYTHON_API=off
-        -DLIEF_ENABLE_JSON=off
-        -DLIEF_EXAMPLES=off
-        -DLIEF_DOC=off
-        -DLIEF_COVERAGE=off
-        -DLIEF_EXTRA_WARNINGS=off
-        -DLIEF_ASAN=off
-        -DLIEF_LSAN=off
-        -DLIEF_TSAN=off
-        -DLIEF_FUZZING=off
-        -DLIEF_PROFILING=off
-        -DLIEF_FROZEN_ENABLED=off
-        -DLIEF_INSTALL_COMPILED_EXAMPLES=off
+        -DLIEF_PE=ON
+        -DLIEF_LOGGING=ON
+        -DLIEF_ELF=ON
+        -DLIEF_MACHO=OFF
+        -DLIEF_PYTHON_API=OFF
+        -DLIEF_ENABLE_JSON=OFF
+        -DLIEF_EXAMPLES=OFF
+        -DLIEF_DOC=OFF
+        -DLIEF_COVERAGE=OFF
+        -DLIEF_EXTRA_WARNINGS=OFF
+        -DLIEF_ASAN=OFF
+        -DLIEF_LSAN=OFF
+        -DLIEF_TSAN=OFF
+        -DLIEF_FUZZING=OFF
+        -DLIEF_PROFILING=OFF
+        -DLIEF_FROZEN_ENABLED=OFF
+        -DLIEF_INSTALL_COMPILED_EXAMPLES=OFF
         -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-        -DCCACHE=off
+        -DBUILD_SHARED_LIBS=OFF
+        -DCCACHE=OFF
         )
 
 if(MSVC)
@@ -60,7 +61,7 @@ ExternalProject_Add(LIEF
         UPDATE_COMMAND   ""
         )
 
-add_library(LIEF_SYS SHARED src/liblief.cpp)
+add_library(LIEF_SYS src/liblief.cpp)
 
 if(MSVC)
     target_compile_options(LIEF_SYS PUBLIC /FIiso646.h)

--- a/lief-sys/Cargo.toml
+++ b/lief-sys/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 authors = [ "Alexandr Yusuk <aleksandr.yusuk@apriorit.com>" ]
 edition = "2018"
 build = "build.rs"
-links = "LIEF_SYS"
 
 [build-dependencies]
 cmake = "0.1.45"

--- a/lief-sys/build.rs
+++ b/lief-sys/build.rs
@@ -2,6 +2,7 @@ use std::env;
 use cmake::Config;
 
 fn main() {
+    let target = env::var("TARGET").unwrap();
     let profile = env::var("PROFILE").unwrap();
     let cmake_build_type = if profile == "debug" { "Debug" } else { "Release" };
 
@@ -29,6 +30,13 @@ fn main() {
 
     println!("cargo:rustc-link-search=native={}", lib_path.to_str().unwrap());
     println!("cargo:rustc-link-lib=static=lief-sys");
+
+    // link to C++ runtime
+    if target.contains("linux") {
+        println!("cargo:rustc-link-lib=dylib=stdc++");
+    } else if target.contains("apple") {
+        println!("cargo:rustc-link-lib=dylib=c++");
+    }
 
     println!("cargo:root={}", install_dir.to_str().unwrap());
 }

--- a/lief-sys/build.rs
+++ b/lief-sys/build.rs
@@ -6,6 +6,7 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     let install_dir = Config::new(".")
+        .define("BUILD_SHARED_LIBS", "OFF")
         .static_crt(false)
         .no_build_target(true)
         .build();
@@ -31,6 +32,6 @@ fn main() {
         );
     }
 
-    println!("cargo:rustc-link-lib=dylib=LIEF_SYS");
+    println!("cargo:rustc-link-lib=static=LIEF_SYS");
     println!("cargo:root={}", install_dir.to_str().unwrap());
 }


### PR DESCRIPTION
We link everything statically inside both wayk-cse-patcher and den-server, so the usage of a shared library would have meant a significant change in the deployment of both projects. I understand it's tricky to correctly link statically both lief-sys, the original LIEF library and the C++ runtime, but I managed to get it working. To test that linking works, you need to build wayk-cse against this lief-rs branch, or build the tests in lief-rs (it'll generate an executable - and therefore link everything). I noticed that some unit tests fail but I don't think it has to do with the changes I've made, I suspect they were failing before that.